### PR TITLE
chore: uses new pluginInterface version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [1.14.0] - 2022-05-05
+- New plugin version (v2.14)
+
 ## [1.13.0] - 2022-03-17
 
 - Fixes issue with memory leak during tests

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.13.0"
+version = "1.14.0"
 
 repositories {
     mavenCentral()

--- a/pluginInterfaceSupported.json
+++ b/pluginInterfaceSupported.json
@@ -1,6 +1,6 @@
 {
   "_comment": "contains a list of plugin interfaces branch names that this core supports",
   "versions": [
-    "2.13"
+    "2.14"
   ]
 }


### PR DESCRIPTION
## Summary of change
Updates plugin interface version

## Related issues
- https://github.com/supertokens/supertokens-plugin-interface/pull/34

## Test Plan
- none

## Documentation changes
- none

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.

## Remaining TODOs for this PR
- none