### PR TITLE
fix: make addArrayKeyValue_Transaction handle adding to empty lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Fixed an issue when adding new access token signing key to an empty list
+
 ## [1.22.0] - 2023-03-30
 
 - New plugin version (v2.22)

--- a/src/main/java/io/supertokens/storage/mongodb/Queries.java
+++ b/src/main/java/io/supertokens/storage/mongodb/Queries.java
@@ -219,10 +219,14 @@ public class Queries {
         } else {
 
             try {
-                collection.insertOne(new Document("_id", key).append("keys", keyList));
+                UpdateResult result = collection.updateOne(
+                        Filters.and(Filters.eq("_id", key), Filters.size("keys", 0)),
+                        // We have to use a pushEach with here, because it allows us to set where we push the value
+                        Updates.pushEach("keys", keyList, new PushOptions().position(0)),
+                        new UpdateOptions().upsert(true));
 
                 // TODO: supposed to call this only if result.wasAcknowledged() is true. Why?
-                return true;
+                return result.getModifiedCount() == 1;
             } catch (MongoException e) {
                 if (!isDuplicateKeyException(e)) {
                     throw e;

--- a/src/test/java/io/supertokens/storage/mongodb/test/KeyValueInfoArrayTest.java
+++ b/src/test/java/io/supertokens/storage/mongodb/test/KeyValueInfoArrayTest.java
@@ -31,8 +31,7 @@ import org.junit.Test;
 import org.junit.rules.TestRule;
 
 import static junit.framework.TestCase.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 public class KeyValueInfoArrayTest {
     @Rule
@@ -153,4 +152,28 @@ public class KeyValueInfoArrayTest {
         assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
     }
 
+    @Test
+    public void checkThatAddWorksWorksWithEmptyList() throws InterruptedException, StorageQueryException {
+        String[] args = { "../" };
+        TestingProcessManager.TestingProcess process = TestingProcessManager.start(args);
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STARTED));
+
+        SessionStorage sessionStorage = StorageLayer.getSessionStorage(process.getProcess());
+        if (sessionStorage.getType() != STORAGE_TYPE.NOSQL_1) {
+            return;
+        }
+        SessionNoSQLStorage_1 noSQLSessionStorage_1 = (SessionNoSQLStorage_1) sessionStorage;
+
+        noSQLSessionStorage_1.addAccessTokenSigningKey_Transaction(new KeyValueInfo("key1", 100), null);
+
+        noSQLSessionStorage_1.removeAccessTokenSigningKeysBefore(199);
+
+        assert noSQLSessionStorage_1.addAccessTokenSigningKey_Transaction(new KeyValueInfo("key3", 200), null);
+
+        KeyValueInfo[] allKeys = noSQLSessionStorage_1.getAccessTokenSigningKeys_Transaction();
+        assertEquals(allKeys.length, 1);
+
+        process.kill();
+        assertNotNull(process.checkOrWaitForEvent(ProcessState.PROCESS_STATE.STOPPED));
+    }
 }


### PR DESCRIPTION
## Summary of change
make `addArrayKeyValue_Transaction ` handle adding to empty lists
this fixes an infinite loop when all keys have expired and been removed before generating a new one.

## Related issues
- 

## Test Plan
Added a test to check that `addArrayKeyValue_Transaction` handles the above case

## Documentation changes
N/A, bugfix

## Checklist for important updates
- [x] Changelog has been updated
- [x] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
