### PR TITLE
feat: Add support to update the signing key type of a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+- Adds a new `useStaticKey` param to `updateSessionInfo_Transaction`
+  - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
+    change the signing key type of a session
+
 ## [1.25.0] - 2023-09-19
 
 - Compatibility with plugin interface 4.0.0

--- a/src/main/java/io/supertokens/storage/mongodb/Queries.java
+++ b/src/main/java/io/supertokens/storage/mongodb/Queries.java
@@ -264,7 +264,7 @@ public class Queries {
     }
 
     static boolean updateSessionInfo_Transaction(Start start, String sessionHandle, String refreshTokenHash2,
-            long expiry, String lastUpdatedSign) throws StorageQueryException {
+            long expiry, String lastUpdatedSign, boolean useStaticKey) throws StorageQueryException {
 
         if (lastUpdatedSign == null) {
             throw new StorageQueryException(new Exception("lastUpdatedSign cannot be null for this update operation"));
@@ -274,7 +274,7 @@ public class Queries {
         MongoCollection collection = client.getCollection(Config.getConfig(start).getSessionInfoCollection());
 
         Document toUpdate = new Document("$set", new Document("refresh_token_hash_2", refreshTokenHash2)
-                .append("expires_at", expiry).append("last_updated_sign", Utils.getUUID()));
+                .append("expires_at", expiry).append("last_updated_sign", Utils.getUUID()).append("use_static_key", useStaticKey));
 
         UpdateResult result = collection.updateOne(
                 Filters.and(Filters.eq("_id", sessionHandle), Filters.eq("last_updated_sign", lastUpdatedSign)),

--- a/src/main/java/io/supertokens/storage/mongodb/Start.java
+++ b/src/main/java/io/supertokens/storage/mongodb/Start.java
@@ -139,10 +139,10 @@ public class Start implements SessionNoSQLStorage_1, JWTRecipeNoSQLStorage_1 {
 
     @Override
     public boolean updateSessionInfo_Transaction(String sessionHandle, String refreshTokenHash2, long expiry,
-            String lastUpdatedSign) throws StorageQueryException {
+            String lastUpdatedSign, boolean useStaticKey) throws StorageQueryException {
         try {
             return Queries.updateSessionInfo_Transaction(this, sessionHandle, refreshTokenHash2, expiry,
-                    lastUpdatedSign);
+                    lastUpdatedSign, useStaticKey);
         } catch (MongoException e) {
             throw new StorageQueryException(e);
         }


### PR DESCRIPTION
## Summary of change
feat: Add support to update the signing key type of a session

## Related issues

- core: https://github.com/supertokens/supertokens-core/pull/909
- plugin-interface: https://github.com/supertokens/supertokens-plugin-interface/pull/136
- postgresql-plugin: https://github.com/supertokens/supertokens-postgresql-plugin/pull/180
- mysql-plugin: https://github.com/supertokens/supertokens-mysql-plugin/pull/88
- mongodb-plugin: https://github.com/supertokens/supertokens-mongodb-plugin/pull/31
- node: https://github.com/supertokens/supertokens-node/pull/782

## Test Plan
Done in core PR

## Documentation changes
Done in core PR

## Checklist for important updates
- [x] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [x] Had installed and ran the pre-commit hook
- [x] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [x] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
