### PR TITLE
fix: error logs should be printed to StdErr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Adds a new `useStaticKey` param to `updateSessionInfo_Transaction`
   - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
     change the signing key type of a session
-
-## [1.25.1] - 2024-02-06
-
 - Fixes issue where error logs were printed to StdOut instead of StdErr.
 
 ## [1.25.0] - 2023-09-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - This enables smooth switching between `useDynamicAccessTokenSigningKey` settings by allowing refresh calls to
     change the signing key type of a session
 
+## [1.25.1] - 2024-02-06
+
+- Fixes issue where error logs were printed to StdOut instead of StdErr.
+
 ## [1.25.0] - 2023-09-19
 
 - Compatibility with plugin interface 4.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.25.0"
+version = "1.25.1"
 
 repositories {
     mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-library'
 }
 
-version = "1.25.1"
+version = "1.25.0"
 
 repositories {
     mavenCentral()

--- a/src/main/java/io/supertokens/storage/mongodb/output/Logging.java
+++ b/src/main/java/io/supertokens/storage/mongodb/output/Logging.java
@@ -37,10 +37,10 @@ public class Logging extends ResourceDistributor.SingletonResource {
 
     private Logging(Start start, String infoLogPath, String errorLogPath) {
         this.infoLogger = infoLogPath.equals("null")
-                ? createLoggerForConsole(start, "io.supertokens.storage.mongodb.Info")
+                ? createLoggerForConsole(start, "io.supertokens.storage.mongodb.Info", LOG_LEVEL.INFO)
                 : createLoggerForFile(start, infoLogPath, "io.supertokens.storage.mongodb.Info");
         this.errorLogger = errorLogPath.equals("null")
-                ? createLoggerForConsole(start, "io.supertokens.storage.mongodb.Error")
+                ? createLoggerForConsole(start, "io.supertokens.storage.mongodb.Error", LOG_LEVEL.ERROR)
                 : createLoggerForFile(start, errorLogPath, "io.supertokens.storage.mongodb.Error");
     }
 
@@ -189,12 +189,13 @@ public class Logging extends ResourceDistributor.SingletonResource {
         return logger;
     }
 
-    private Logger createLoggerForConsole(Start start, String name) {
+    private Logger createLoggerForConsole(Start start, String name, LOG_LEVEL logLevel) {
         LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
         LayoutWrappingEncoder ple = new LayoutWrappingEncoder(start.getProcessId());
         ple.setContext(lc);
         ple.start();
         ConsoleAppender<ILoggingEvent> logConsoleAppender = new ConsoleAppender<>();
+        logConsoleAppender.setTarget(logLevel == LOG_LEVEL.ERROR ? "System.err" : "System.out");
         logConsoleAppender.setEncoder(ple);
         logConsoleAppender.setContext(lc);
         logConsoleAppender.start();


### PR DESCRIPTION
## Summary of change

Fixes issue where error logs were printed to StdOut instead of StdErr. 

## Related issues
- Link to issue1 here
- Link to issue1 here

## Test Plan
(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Documentation changes
(If relevant, please create a PR in our [docs repo](https://github.com/supertokens/docs), or create a checklist here highlighting the necessary changes)

## Checklist for important updates
- [ ] Changelog has been updated
- [ ] `pluginInterfaceSupported.json` file has been updated (if needed)
- [ ] Changes to the version if needed
   - In `build.gradle`
- [ ] Had installed and ran the pre-commit hook
- [ ] If there are new dependencies that have been added in `build.gradle`, please make sure to add them in `implementationDependencies.json`.
- [ ] Issue this PR against the latest non released version branch.
   - To know which one it is, run find the latest released tag (`git tag`) in the format `vX.Y.Z`, and then find the latest branch (`git branch --all`) whose `X.Y` is greater than the latest released tag.
   - If no such branch exists, then create one from the latest released branch.
